### PR TITLE
Changed docinfo

### DIFF
--- a/source/bookinfo.xml
+++ b/source/bookinfo.xml
@@ -59,7 +59,7 @@
   <feedback>
     <url>http://gvsu.edu/s/0vK</url>
   </feedback>
-  <document-id>boelkins-ACS</document-id>
+  <document-id>safranski-acs</document-id>
   <rename element="exploration" xml:lang="en-US">Preview Activity</rename>
 
   <rename element="objectives" xml:lang="en-US">Motivating Questions</rename>


### PR DESCRIPTION
There was some trouble this weekend because the docinfo was boelkins-ACS but should have been safranski-acs for this version.

I think I changed it in the right place so that there won't be any issue for the next weekly rebuild, but maybe check with Brad?